### PR TITLE
Add hybrid ranking to retriever

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,10 @@
 
 [tool.ruff]
 extend-include = ["*.ipynb"]
+
+[project]
+name = "raggler"
+version = "0.1.0"
+dependencies = [
+    "rank_bm25",
+]

--- a/raggler/indexes.py
+++ b/raggler/indexes.py
@@ -2,6 +2,7 @@ import pickle
 
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
+from rank_bm25 import BM25Okapi
 from raggler.base_classes.base_classes import BaseIndex
 
 
@@ -16,6 +17,7 @@ class NPIndex(BaseIndex):
     ):
         self.index = None
         self.content = None
+        self.bm25 = None
 
     def add(self, vectors: np.ndarray, content: list[str]):
         """
@@ -27,6 +29,8 @@ class NPIndex(BaseIndex):
 
         self.index = vectors
         self.content = content
+        tokenized_content = [c.split() for c in self.content]
+        self.bm25 = BM25Okapi(tokenized_content)
 
     def save(self, path_to_save_index: str):
         """
@@ -39,6 +43,9 @@ class NPIndex(BaseIndex):
         with open(path_to_save_index + "content.pk", "wb") as f:
             pickle.dump(self.content, f)
 
+        with open(path_to_save_index + "bm25.pk", "wb") as f:
+            pickle.dump(self.bm25, f)
+
     def load(self, path_to_index: str):
         """
         Load the index from the given path.
@@ -49,27 +56,48 @@ class NPIndex(BaseIndex):
         with open(path_to_index + "content.pk", "rb") as f:
             self.content = pickle.load(f)
 
+        with open(path_to_index + "bm25.pk", "rb") as f:
+            self.bm25 = pickle.load(f)
+
     def retrieve(
-        self, query_embedding: np.ndarray, k: int
+        self, query_embedding: np.ndarray, query_text: str, k: int
     ) -> tuple[np.ndarray, list[int]]:
         """
         Retrieve the most similar documents to the given query.
-        Use cosine similarity to compare the query to
-            the documents in the index.
+        Use cosine similarity for semantic search and BM25 for lexical search.
 
         Args:
             query_embedding: The embedding of the query.
+            query_text: The text of the query.
             k: The number of documents to retrieve.
 
         Returns:
-            tuple[np.ndarray, np.ndarray]: The distances and indices of the most similar documents.
+            tuple[np.ndarray, np.ndarray]: The combined scores and indices of the most similar documents.
         """
         if len(query_embedding.shape) == 1:
             # single query
             query_embedding = query_embedding.reshape(1, -1)
 
-        distances = cosine_similarity(query_embedding, self.index)[0]
+        # Semantic search
+        semantic_scores = cosine_similarity(query_embedding, self.index)[0]
 
-        actual_k = min(k, len(distances))
-        indices = distances.argsort()[-actual_k:]
-        return distances[indices], indices
+        # Lexical search
+        tokenized_query = query_text.split()
+        lexical_scores = self.bm25.get_scores(tokenized_query)
+
+        # Normalize scores (min-max scaling to 0-1 range)
+        # Add a small epsilon to avoid division by zero if all scores are the same
+        epsilon = 1e-9
+        normalized_semantic_scores = (semantic_scores - np.min(semantic_scores)) / (
+            np.max(semantic_scores) - np.min(semantic_scores) + epsilon
+        )
+        normalized_lexical_scores = (lexical_scores - np.min(lexical_scores)) / (
+            np.max(lexical_scores) - np.min(lexical_scores) + epsilon
+        )
+        
+        # Combine scores
+        combined_scores = 0.5 * normalized_semantic_scores + 0.5 * normalized_lexical_scores
+        
+        actual_k = min(k, len(combined_scores))
+        indices = combined_scores.argsort()[-actual_k:][::-1]  # Sort in descending order
+        return combined_scores[indices], indices

--- a/raggler/indexes.py
+++ b/raggler/indexes.py
@@ -100,4 +100,4 @@ class NPIndex(BaseIndex):
         
         actual_k = min(k, len(combined_scores))
         indices = combined_scores.argsort()[-actual_k:][::-1]  # Sort in descending order
-        return combined_scores[indices], indices
+        return combined_scores[indices], indices.tolist()

--- a/raggler/rag.py
+++ b/raggler/rag.py
@@ -118,7 +118,7 @@ class RAG:
         Retrieve the most similar documents to the given query.
         """
         query_vector = self.embedder.encode([query])
-        distances, indices = self.index.retrieve(query_vector, k)
+        distances, indices = self.index.retrieve(query_embedding=query_vector, query_text=query, k=k)
 
         return distances, list(indices.flatten())
 

--- a/tests/test_np_index.py
+++ b/tests/test_np_index.py
@@ -36,3 +36,37 @@ def test_save(tmp_path):
     index.load(tmp_path)
     assert np.array_equal(index.index, vectors)
     assert index.content == content
+
+
+def test_hybrid_retrieval():
+    index = NPIndex()
+    # Sample data with some overlapping terms for BM25
+    vectors = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+    content = [
+        "apple banana orange",
+        "apple pie recipe",
+        "orange juice benefits",
+    ]
+    index.add(vectors, content)
+
+    # Sample query
+    query_text = "apple recipe"
+    # Dummy embedding for the query (actual embedding values don't matter for this test)
+    query_embedding = np.array([0.15, 0.25, 0.35]) 
+    k = 1
+
+    distances, indices = index.retrieve(
+        query_embedding=query_embedding, query_text=query_text, k=k
+    )
+
+    # Assert that results are not empty
+    assert len(distances) > 0, "Distances should not be empty"
+    assert len(indices) > 0, "Indices should not be empty"
+
+    # Assert shape of the results
+    assert distances.shape == (k,), f"Distances shape should be ({k},), but got {distances.shape}"
+    assert indices.shape == (k,), f"Indices shape should be ({k},), but got {indices.shape}"
+
+    # Assert that indices are within the valid range
+    for idx in indices:
+        assert 0 <= idx < len(content), f"Index {idx} is out of bounds"


### PR DESCRIPTION
Having fun with GenAI.


----
This commit introduces hybrid ranking capabilities to the retriever by:

1. Modifying `NPIndex` to support lexical search using BM25:
    - Integrated `rank_bm25` library for BM25 scoring.
    - Updated `add`, `save`, and `load` methods to handle the BM25 model.
    - Modified the `retrieve` method to compute both semantic (cosine similarity) and lexical (BM25) scores.
    - Implemented min-max normalization for both scores and combined them using a 50/50 weighted sum.

2. Updating `RAG.retrieve` to pass the query text to `NPIndex.retrieve`, enabling the new hybrid logic.

3. Adding a new unit test (`test_hybrid_retrieval` in `tests/test_np_index.py`) to verify the functionality of the hybrid retrieval pipeline, ensuring it runs without errors and returns results in the expected format.