### PR TITLE
feat: Implement hybrid search for FAISSIndex

### DIFF
--- a/raggler/faiss_index.py
+++ b/raggler/faiss_index.py
@@ -6,6 +6,8 @@ When ready to fix, add faiss to the requirements.txt file.
 
 import faiss
 import pickle
+import numpy as np
+from rank_bm25 import BM25Okapi
 from raggler.base_classes.base_classes import BaseIndex
 
 
@@ -13,13 +15,18 @@ class FAISSIndex(BaseIndex):
     def __init__(self, d: int):
         self.index = faiss.IndexIDMap2(faiss.IndexFlatL2(d))
         self.content = []
+        self.bm25 = None
 
-    def add(self, vectors, content):
+    def add(self, vectors: np.ndarray, content: list[str]):
         """
         Add the given vectors to the index, alongside the given content.
         """
-        self.index.add_with_ids(vectors, range(len(content)))
-        self.content.append(content)
+        assert vectors.shape[0] == len(content)
+        self.content = content
+        ids = np.arange(len(content))
+        self.index.add_with_ids(vectors, ids)
+        tokenized_content = [doc.split() for doc in self.content]
+        self.bm25 = BM25Okapi(tokenized_content)
 
     def save(self, path_to_save_index):
         """
@@ -29,6 +36,10 @@ class FAISSIndex(BaseIndex):
 
         with open(path_to_save_index + "content.pk", "wb") as f:
             pickle.dump(self.content, f)
+        
+        if self.bm25:
+            with open(path_to_save_index + "bm25.pk", "wb") as f:
+                pickle.dump(self.bm25, f)
 
     def load(self, path_to_index):
         """
@@ -38,15 +49,98 @@ class FAISSIndex(BaseIndex):
 
         with open(path_to_index + "content.pk", "rb") as f:
             self.content = pickle.load(f)
+        
+        try:
+            with open(path_to_index + "bm25.pk", "rb") as f:
+                self.bm25 = pickle.load(f)
+        except FileNotFoundError:
+            self.bm25 = None # Consistent with __init__
 
-    def retrieve(self, query_embedding, k: int = 2):
+    def _normalize_scores(self, scores: np.ndarray) -> np.ndarray:
         """
-        Retrieve the most similar documents to the given query.
+        Min-max normalize scores to the 0-1 range.
+        Handles cases where all scores are the same.
+        """
+        min_val = np.min(scores)
+        max_val = np.max(scores)
+        delta = max_val - min_val
+        if delta == 0:
+            # All scores are the same. Return array of 0.5s as a neutral value,
+            # indicating no discriminative power from this score type but contributing neutrally.
+            return np.full_like(scores, 0.5, dtype=np.float32)
+        return (scores - min_val) / delta
+
+    def retrieve(self, query_embedding: np.ndarray, query_text: str, k: int = 2) -> tuple[np.ndarray, list[int]]:
+        """
+        Retrieve the most similar documents to the given query using a combination of
+        semantic (FAISS) and lexical (BM25) search.
 
         Args:
-            query_embedding: The query to retrieve the most similar documents to.
+            query_embedding: The embedding of the query.
+            query_text: The text of the query.
             k: The number of documents to retrieve.
 
-        Should return the distances and indices of the k most similar documents.
+        Returns:
+            A tuple containing an array of combined scores and a list of document indices.
         """
-        raise NotImplementedError("Sorry, this method is not implemented yet.")
+        if not self.content or self.bm25 is None:
+            return np.array([]), []
+
+        # Prepare Query Embedding
+        if query_embedding.ndim == 1:
+            query_embedding = query_embedding.reshape(1, -1)
+        query_embedding = query_embedding.astype(np.float32)
+
+        # Handle single document case separately for simplicity in normalization
+        if len(self.content) == 1:
+            # FAISS search to check if the query matches the dimension
+            # This also implicitly checks if self.index is not empty or malformed for search
+            try:
+                # We don't strictly need the result, just that search doesn't error
+                _ = self.index.search(query_embedding, k=1)
+            except Exception: # Catch potential FAISS errors with malformed query/index
+                return np.array([]), [] # Or handle error more gracefully
+            return np.array([1.0], dtype=np.float32), [0]
+
+
+        # 1. Semantic Search (FAISS)
+        # Search for all documents to get a complete score list
+        distances_flat, indices_flat = self.index.search(query_embedding, k=len(self.content))
+        
+        distances_flat = distances_flat[0]
+        indices_flat = indices_flat[0]
+
+        valid_mask = indices_flat != -1
+        valid_indices = indices_flat[valid_mask]
+        valid_distances = distances_flat[valid_mask]
+
+        semantic_distance_map = {idx: dist for idx, dist in zip(valid_indices, valid_distances)}
+        
+        all_semantic_scores_raw = np.array([semantic_distance_map.get(i, float('inf')) for i in range(len(self.content))], dtype=np.float32)
+        
+        # Convert distances to similarity scores (higher is better)
+        # L2 distances are non-negative, so 1 + distance is > 0 (unless distance is -1, which we filtered)
+        all_semantic_scores = 1.0 / (1.0 + all_semantic_scores_raw)
+
+        # 2. Lexical Search (BM25)
+        tokenized_query = query_text.split()
+        all_lexical_scores = self.bm25.get_scores(tokenized_query)
+        all_lexical_scores = np.array(all_lexical_scores, dtype=np.float32)
+
+        # 3. Normalize Scores
+        norm_semantic_scores = self._normalize_scores(all_semantic_scores)
+        norm_lexical_scores = self._normalize_scores(all_lexical_scores)
+
+        # 4. Combine Scores
+        combined_scores = 0.5 * norm_semantic_scores + 0.5 * norm_lexical_scores
+
+        # 5. Get Top K Results
+        actual_k = min(k, len(self.content))
+        
+        # Argsort sorts in ascending order, so we take the last k and reverse them for descending order
+        top_k_indices = np.argsort(combined_scores)[-actual_k:][::-1]
+        
+        final_scores = combined_scores[top_k_indices]
+        final_indices = top_k_indices.tolist()
+
+        return final_scores, final_indices

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pypdf==4.0.2
 fire==0.5.0
 torch==2.2.1
 python-dotenv==1.0.1
+faiss-cpu
+rank-bm25

--- a/tests/test_faiss_index.py
+++ b/tests/test_faiss_index.py
@@ -1,0 +1,164 @@
+import pytest
+import numpy as np
+from raggler.faiss_index import FAISSIndex
+
+# Test for adding vectors and content, then retrieving
+def test_add_and_retrieve_simple():
+    index = FAISSIndex(d=3)
+    vectors = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    content = ["apple", "banana"]
+    index.add(vectors, content)
+
+    assert index.content == content, "Content not stored correctly"
+    assert index.bm25 is not None, "BM25 not initialized"
+    assert index.index.ntotal == 2, "Incorrect number of vectors in FAISS index"
+
+    query_embedding = np.array([1, 2, 3], dtype=np.float32)
+    query_text = "apple"
+    scores, indices = index.retrieve(query_embedding, query_text, k=1)
+
+    assert len(scores) == 1, "Incorrect number of scores returned"
+    assert len(indices) == 1, "Incorrect number of indices returned"
+    assert index.content[indices[0]] == "apple", "Retrieved content mismatch"
+
+# Test for saving and loading the index
+def test_save_load(tmp_path):
+    index = FAISSIndex(d=2)
+    vectors = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+    content = ["doc1", "doc2"]
+    index.add(vectors, content)
+
+    save_path = str(tmp_path) + "/" # FAISS save/load might need directory-like path
+    index.save(save_path)
+
+    loaded_index = FAISSIndex(d=2)
+    loaded_index.load(save_path)
+
+    assert loaded_index.content == content, "Loaded content mismatch"
+    assert loaded_index.index.ntotal == 2, "Loaded FAISS index ntotal mismatch"
+    assert loaded_index.bm25 is not None, "Loaded BM25 is None"
+    # Check if BM25 has indexed the correct number of documents by checking corpus size or similar
+    assert len(loaded_index.bm25.get_scores("doc1".split())) == len(content), "BM25 doc count mismatch after load"
+
+
+    query_embedding = np.array([0.1, 0.2], dtype=np.float32)
+    query_text = "doc1"
+    scores, indices = loaded_index.retrieve(query_embedding, query_text, k=1)
+
+    assert len(scores) == 1, "Retrieval from loaded index failed (scores)"
+    assert len(indices) == 1, "Retrieval from loaded index failed (indices)"
+    assert loaded_index.content[indices[0]] == "doc1", "Retrieved content mismatch from loaded index"
+
+# Test for hybrid retrieval ranking logic
+def test_hybrid_retrieval_ranking():
+    index = FAISSIndex(d=2)
+    vectors = np.array([
+        [0.9, 0.1],  # Doc A: Semantically like "query_sem"
+        [0.1, 0.9],  # Doc B: Semantically different, but lexically like "query_lex"
+        [0.8, 0.2],  # Doc C: Semantically similar, also some lexical overlap
+    ], dtype=np.float32)
+    content = [
+        "semantic match here",      # Doc A (index 0)
+        "lexical match there",      # Doc B (index 1)
+        "semantic and lexical too", # Doc C (index 2)
+    ]
+    index.add(vectors, content)
+
+    query_embedding = np.array([0.95, 0.05], dtype=np.float32)  # Targets Doc A and C semantically
+    query_text = "lexical too"  # Targets Doc B and C lexically
+
+    scores, indices = index.retrieve(query_embedding, query_text, k=3)
+    
+    retrieved_content_ordered = [content[i] for i in indices]
+
+    assert len(scores) == 3, "Should return 3 scores"
+    assert len(indices) == 3, "Should return 3 indices"
+    assert len(set(retrieved_content_ordered)) == 3, "All unique documents should be returned"
+
+    # Expected: Doc C is top due to combined semantic and lexical match.
+    assert retrieved_content_ordered[0] == "semantic and lexical too", \
+        f"Doc C ('semantic and lexical too') expected first. Got: {retrieved_content_ordered}"
+
+    # Doc A ("semantic match here") and Doc B ("lexical match there") are next.
+    # We need to ensure Doc C's score is higher than both A and B.
+    score_C = scores[0] # Since Doc C is asserted to be first.
+
+    try:
+        idx_A_in_results = retrieved_content_ordered.index("semantic match here")
+        score_A = scores[idx_A_in_results]
+        assert score_C >= score_A, f"Score of C ({score_C}) should be >= score of A ({score_A})"
+    except ValueError:
+        assert False, "Doc A ('semantic match here') not found in results"
+
+    try:
+        idx_B_in_results = retrieved_content_ordered.index("lexical match there")
+        score_B = scores[idx_B_in_results]
+        assert score_C >= score_B, f"Score of C ({score_C}) should be >= score of B ({score_B})"
+    except ValueError:
+        assert False, "Doc B ('lexical match there') not found in results"
+
+    # Ensure the order of A and B (if they are not C) is such that higher score comes first
+    if "semantic match here" in retrieved_content_ordered[1:] and \
+       "lexical match there" in retrieved_content_ordered[1:]:
+        idx_A_in_results = retrieved_content_ordered.index("semantic match here")
+        idx_B_in_results = retrieved_content_ordered.index("lexical match there")
+        
+        # If A is ranked higher than B in results, its score should be >= B's score
+        if idx_A_in_results < idx_B_in_results:
+            assert scores[idx_A_in_results] >= scores[idx_B_in_results], \
+                f"Doc A ranked before Doc B, but score A ({scores[idx_A_in_results]}) < score B ({scores[idx_B_in_results]})"
+        # If B is ranked higher than A in results, its score should be >= A's score
+        else: # idx_B_in_results < idx_A_in_results
+            assert scores[idx_B_in_results] >= scores[idx_A_in_results], \
+                f"Doc B ranked before Doc A, but score B ({scores[idx_B_in_results]}) < score A ({scores[idx_A_in_results]})"
+
+# Test retrieving from an empty index
+def test_retrieve_empty_index():
+    index = FAISSIndex(d=2)
+    query_embedding = np.array([0.1, 0.2], dtype=np.float32)
+    query_text = "query"
+    scores, indices = index.retrieve(query_embedding, query_text, k=1)
+
+    assert len(scores) == 0, "Scores should be empty for empty index"
+    assert len(indices) == 0, "Indices should be empty for empty index"
+
+# Test retrieving when only a single document is in the index
+def test_retrieve_single_document_in_index():
+    index = FAISSIndex(d=2)
+    vectors = np.array([[0.1, 0.2]], dtype=np.float32)
+    content = ["single doc"]
+    index.add(vectors, content)
+
+    query_embedding = np.array([0.1, 0.2], dtype=np.float32)
+    query_text = "single" 
+    scores, indices = index.retrieve(query_embedding, query_text, k=1)
+
+    assert len(scores) == 1, "Should return 1 score for single doc"
+    assert np.isclose(scores[0], 1.0), f"Score for single doc should be approx 1.0, got {scores[0]}"
+    assert len(indices) == 1, "Should return 1 index for single doc"
+    assert indices[0] == 0, "Index for single doc should be 0"
+    assert index.content[indices[0]] == "single doc"
+
+# Test retrieving when k is greater than the number of documents
+def test_retrieve_k_greater_than_docs():
+    index = FAISSIndex(d=2)
+    vectors = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+    content = ["doc1", "doc2"]
+    index.add(vectors, content)
+
+    query_embedding = np.array([0.1, 0.2], dtype=np.float32) 
+    query_text = "doc1" 
+    scores, indices = index.retrieve(query_embedding, query_text, k=5)
+
+    assert len(scores) == 2, "Should return 2 scores when k > num_docs (actual number of docs)"
+    assert len(indices) == 2, "Should return 2 indices when k > num_docs (actual number of docs)"
+
+    # Check content and order (doc1 should be first due to stronger match with query_embedding and query_text)
+    # This assumes 'doc1' will have a higher combined score than 'doc2' for the given query.
+    # If 'doc2' could rank higher, this assertion would need to be more flexible.
+    if len(scores) == 2: # Ensure we have two scores to compare
+        assert index.content[indices[0]] == "doc1", "doc1 expected first"
+        assert index.content[indices[1]] == "doc2", "doc2 expected second"
+        assert scores[0] >= scores[1], "Scores should be in descending order"
+    elif len(scores) == 1: # Only one doc returned
+        assert index.content[indices[0]] == "doc1", "If only one doc, it should be doc1"


### PR DESCRIPTION
This commit introduces hybrid search functionality to `FAISSIndex`, enabling it to perform both semantic and lexical searches, similar to `NPIndex`.

Key changes include:
- Modified `FAISSIndex.__init__` and `FAISSIndex.add` to initialize and build a `BM25Okapi` index alongside the FAISS index. All documents and vectors are now expected in a single `add` call.
- Implemented `FAISSIndex.retrieve` to:
    - Perform semantic search using the FAISS index.
    - Perform lexical search using the BM25 index on the document content.
    - Normalize both sets of scores (semantic and lexical) to a 0-1 range. Special handling for cases with single documents or uniform scores ensures stable normalization.
    - Combine the normalized scores using a 50/50 weighting.
    - Return the top `k` documents based on the combined scores.
- Updated `FAISSIndex.save` and `FAISSIndex.load` to persist and retrieve the BM25 index (`bm25.pk`) along with the FAISS index and content.
- Added `faiss-cpu` and `rank-bm25` to `requirements.txt`.
- Created `tests/test_faiss_index.py` with a comprehensive suite of tests covering `add`, `save`/`load`, and various scenarios for `retrieve`, including simple retrieval, hybrid ranking logic, empty index, single document index, and `k` greater than available documents.

This makes `FAISSIndex` a more powerful and versatile indexing option within the raggler library.